### PR TITLE
fix deprecated declaration in php 8.2

### DIFF
--- a/src/AbstractExtendedPdo.php
+++ b/src/AbstractExtendedPdo.php
@@ -87,7 +87,7 @@ abstract class AbstractExtendedPdo extends PDO implements ExtendedPdoInterface
 
         if (!method_exists($this->pdo, $name)) {
             $class = static::class;
-            $message = "Class '${class}' does not have a method '${name}'";
+            $message = "Class '{$class}' does not have a method '{$name}'";
 
             throw new BadMethodCallException($message);
         }

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -223,7 +223,7 @@ abstract class AbstractParser implements ParserInterface
         // not an array, retain the placeholder for later
         $this->final_values[$name] = $this->values[$orig];
 
-        return ":${name}";
+        return ":{$name}";
     }
 
     /**
@@ -281,7 +281,7 @@ abstract class AbstractParser implements ParserInterface
         $split = implode('|', $this->split);
 
         return preg_split(
-            "/(${split})/um",
+            "/({$split})/um",
             $statement,
             -1,
             PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY


### PR DESCRIPTION
It's deprecated to declare variables in this way `${var}`, it should be defined like this `{$var}`
![image](https://github.com/productsupcom/Aura.Sql/assets/10911162/75158cce-cf4b-4ddf-a18b-156146d85987)
